### PR TITLE
feat(tools): ✨ add view_wave_cute_detail tool

### DIFF
--- a/.xmcp/adapter/index.js
+++ b/.xmcp/adapter/index.js
@@ -31,6 +31,17 @@ module.exports = require("../../src/tools/fetch-wave-hack.ts");
 
 /***/ }),
 
+/***/ "../src/tools/view-wave-cute-detail.ts":
+/*!***********************************************************!*\
+  !*** external "../../src/tools/view-wave-cute-detail.ts" ***!
+  \***********************************************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("../../src/tools/view-wave-cute-detail.ts");
+
+/***/ }),
+
 /***/ "../src/tools/view-wave-cute.ts":
 /*!****************************************************!*\
   !*** external "../../src/tools/view-wave-cute.ts" ***!
@@ -59,7 +70,7 @@ eval("{/* provided dependency */ var INJECTED_TOOLS = __webpack_require__(/*! ./
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
-eval("{__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   prompts: () => (/* binding */ prompts),\n/* harmony export */   resources: () => (/* binding */ resources),\n/* harmony export */   tools: () => (/* binding */ tools)\n/* harmony export */ });\n\nconst tools = {\n\"src/tools/fetch-akindo-data.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/fetch-akindo-data.ts */ \"../src/tools/fetch-akindo-data.ts\", 23)),\n\"src/tools/fetch-wave-hack.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/fetch-wave-hack.ts */ \"../src/tools/fetch-wave-hack.ts\", 23)),\n\"src/tools/view-wave-cute.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/view-wave-cute.ts */ \"../src/tools/view-wave-cute.ts\", 23)),\n};\n\nconst prompts = {\n\n};\n\nconst resources = {\n\n};\n\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi8ueG1jcC9pbXBvcnQtbWFwLmpzIiwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vTmV4dC5qcyB3aXRoIEFkYXB0ZXIvLi8ueG1jcC9pbXBvcnQtbWFwLmpzPzY2MTIiXSwic291cmNlc0NvbnRlbnQiOlsiXG5leHBvcnQgY29uc3QgdG9vbHMgPSB7XG5cInNyYy90b29scy9mZXRjaC1ha2luZG8tZGF0YS50c1wiOiAoKSA9PiBpbXBvcnQoXCIuLi9zcmMvdG9vbHMvZmV0Y2gtYWtpbmRvLWRhdGEudHNcIiksXG5cInNyYy90b29scy9mZXRjaC13YXZlLWhhY2sudHNcIjogKCkgPT4gaW1wb3J0KFwiLi4vc3JjL3Rvb2xzL2ZldGNoLXdhdmUtaGFjay50c1wiKSxcblwic3JjL3Rvb2xzL3ZpZXctd2F2ZS1jdXRlLnRzXCI6ICgpID0+IGltcG9ydChcIi4uL3NyYy90b29scy92aWV3LXdhdmUtY3V0ZS50c1wiKSxcbn07XG5cbmV4cG9ydCBjb25zdCBwcm9tcHRzID0ge1xuXG59O1xuXG5leHBvcnQgY29uc3QgcmVzb3VyY2VzID0ge1xuXG59O1xuXG5cbiJdLCJuYW1lcyI6W10sInNvdXJjZVJvb3QiOiIifQ==\n//# sourceURL=webpack-internal:///./.xmcp/import-map.js\n\n}");
+eval("{__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   prompts: () => (/* binding */ prompts),\n/* harmony export */   resources: () => (/* binding */ resources),\n/* harmony export */   tools: () => (/* binding */ tools)\n/* harmony export */ });\n\nconst tools = {\n\"src/tools/fetch-akindo-data.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/fetch-akindo-data.ts */ \"../src/tools/fetch-akindo-data.ts\", 23)),\n\"src/tools/fetch-wave-hack.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/fetch-wave-hack.ts */ \"../src/tools/fetch-wave-hack.ts\", 23)),\n\"src/tools/view-wave-cute-detail.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/view-wave-cute-detail.ts */ \"../src/tools/view-wave-cute-detail.ts\", 23)),\n\"src/tools/view-wave-cute.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/view-wave-cute.ts */ \"../src/tools/view-wave-cute.ts\", 23)),\n};\n\nconst prompts = {\n\n};\n\nconst resources = {\n\n};\n\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi8ueG1jcC9pbXBvcnQtbWFwLmpzIiwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0EiLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly9OZXh0LmpzIHdpdGggQWRhcHRlci8uLy54bWNwL2ltcG9ydC1tYXAuanM/NjYxMiJdLCJzb3VyY2VzQ29udGVudCI6WyJcbmV4cG9ydCBjb25zdCB0b29scyA9IHtcblwic3JjL3Rvb2xzL2ZldGNoLWFraW5kby1kYXRhLnRzXCI6ICgpID0+IGltcG9ydChcIi4uL3NyYy90b29scy9mZXRjaC1ha2luZG8tZGF0YS50c1wiKSxcblwic3JjL3Rvb2xzL2ZldGNoLXdhdmUtaGFjay50c1wiOiAoKSA9PiBpbXBvcnQoXCIuLi9zcmMvdG9vbHMvZmV0Y2gtd2F2ZS1oYWNrLnRzXCIpLFxuXCJzcmMvdG9vbHMvdmlldy13YXZlLWN1dGUtZGV0YWlsLnRzXCI6ICgpID0+IGltcG9ydChcIi4uL3NyYy90b29scy92aWV3LXdhdmUtY3V0ZS1kZXRhaWwudHNcIiksXG5cInNyYy90b29scy92aWV3LXdhdmUtY3V0ZS50c1wiOiAoKSA9PiBpbXBvcnQoXCIuLi9zcmMvdG9vbHMvdmlldy13YXZlLWN1dGUudHNcIiksXG59O1xuXG5leHBvcnQgY29uc3QgcHJvbXB0cyA9IHtcblxufTtcblxuZXhwb3J0IGNvbnN0IHJlc291cmNlcyA9IHtcblxufTtcblxuXG4iXSwibmFtZXMiOltdLCJzb3VyY2VSb290IjoiIn0=\n//# sourceURL=webpack-internal:///./.xmcp/import-map.js\n\n}");
 
 /***/ }),
 

--- a/.xmcp/import-map.js
+++ b/.xmcp/import-map.js
@@ -2,6 +2,7 @@
 export const tools = {
 "src/tools/fetch-akindo-data.ts": () => import("../src/tools/fetch-akindo-data.ts"),
 "src/tools/fetch-wave-hack.ts": () => import("../src/tools/fetch-wave-hack.ts"),
+"src/tools/view-wave-cute-detail.ts": () => import("../src/tools/view-wave-cute-detail.ts"),
 "src/tools/view-wave-cute.ts": () => import("../src/tools/view-wave-cute.ts"),
 };
 

--- a/src/app/(mcp-ui)/view-wave-cute-detail/page.tsx
+++ b/src/app/(mcp-ui)/view-wave-cute-detail/page.tsx
@@ -1,0 +1,638 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  useWidgetProps,
+  useMaxHeight,
+  useDisplayMode,
+  useRequestDisplayMode,
+  useIsChatGptApp,
+} from "@/app/hooks";
+
+import { useCallTool } from "@/app/hooks/use-call-tool";
+
+interface TokenInfo {
+  name: string;
+  address: string;
+  decimals: number;
+}
+
+interface ActiveWaveInfo {
+  openedAt: string;
+  startedAt: string;
+  submissionDeadline: string;
+  judgementDeadline: string;
+  grantAmount?: string;
+}
+
+interface CommunityLinks {
+  websiteUrl?: string;
+  discordUrl?: string;
+  twitterUrl?: string;
+  telegramUrl?: string;
+}
+
+interface JudgingCriterion {
+  id: string;
+  title: string;
+  sort: number;
+  isActive: boolean;
+}
+
+interface WaveCuteDetail {
+  id: string;
+  title: string;
+  description?: string;
+  buildingDays?: number;
+  judgingDays?: number;
+  activeWave: ActiveWaveInfo;
+  grantDenomination?: TokenInfo;
+  community?: CommunityLinks;
+  criteria?: JudgingCriterion[];
+}
+
+interface WaveCuteApiResponse {
+  success: boolean;
+  data?: WaveCuteDetail;
+  error?: string;
+}
+
+const COMMUNITY_CONFIG = [
+  {
+    key: "websiteUrl" as const,
+    icon: "🌐",
+    label: "Website",
+  },
+  {
+    key: "discordUrl" as const,
+    icon: "💬",
+    label: "Discord",
+  },
+  {
+    key: "twitterUrl" as const,
+    icon: "🐦",
+    label: "Twitter / X",
+  },
+  {
+    key: "telegramUrl" as const,
+    icon: "📱",
+    label: "Telegram",
+  },
+];
+
+const formatDate = (value?: string) => {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleString("en-US", {
+      timeZone: "Asia/Jakarta",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return value;
+  }
+};
+
+const getTimeRemaining = (deadline?: string) => {
+  if (!deadline) {
+    return { label: "No deadline provided", variant: "neutral" as const };
+  }
+
+  const now = Date.now();
+  const target = new Date(deadline).getTime();
+  const diff = target - now;
+
+  if (Number.isNaN(target)) {
+    return { label: "Invalid deadline", variant: "neutral" as const };
+  }
+
+  if (diff <= 0) {
+    return { label: "Deadline passed", variant: "expired" as const };
+  }
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor(
+    (diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+  );
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+  const variant =
+    days <= 1 ? "urgent" : days <= 3 ? "soon" : days <= 7 ? "warning" : "good";
+
+  return {
+    label: `${days}d ${hours}h ${minutes}m remaining`,
+    variant,
+  };
+};
+
+const TIMELINE_FIELDS = [
+  { key: "openedAt", label: "Opened" },
+  { key: "startedAt", label: "Started" },
+  { key: "submissionDeadline", label: "Submission Deadline" },
+  { key: "judgementDeadline", label: "Judging Deadline" },
+] as const;
+
+const getBadgeStyles = (variant: ReturnType<typeof getTimeRemaining>["variant"]) => {
+  switch (variant) {
+    case "expired":
+      return "bg-rose-100/80 text-rose-700 dark:bg-rose-900/40 dark:text-rose-200";
+    case "urgent":
+      return "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200";
+    case "soon":
+      return "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200";
+    case "warning":
+      return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-200";
+    case "good":
+      return "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-200";
+    default:
+      return "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300";
+  }
+};
+
+export default function ViewWaveCuteDetailPage() {
+  const widgetProps = useWidgetProps<{ id?: string }>();
+  const maxHeight = useMaxHeight() ?? undefined;
+  const displayMode = useDisplayMode();
+  const requestDisplayMode = useRequestDisplayMode();
+  const isChatGptApp = useIsChatGptApp();
+  const callTool = useCallTool();
+
+  const [waveCute, setWaveCute] = useState<WaveCuteDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const waveCuteId = widgetProps?.id ?? "";
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchWaveCuteDetail = async () => {
+      if (!waveCuteId) {
+        setError("Wave Cute ID is required to view details.");
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      setWaveCute(null);
+
+      try {
+        const response = await fetch(`/api/wave-hack/${waveCuteId}`);
+        const payload: WaveCuteApiResponse = await response.json();
+
+        if (!response.ok || !payload.success || !payload.data) {
+          throw new Error(
+            payload.error || "Unable to load Wave Cute detail from API."
+          );
+        }
+
+        if (!cancelled) {
+          setWaveCute(payload.data);
+        }
+      } catch (apiError) {
+        // Fall back to MCP tool if direct fetch fails (e.g., hosted via MCP only)
+        try {
+          const toolResult = await callTool("fetch_wave_cute", { id: waveCuteId });
+
+          if (cancelled || toolResult == null) {
+            throw apiError;
+          }
+
+          const parsed = JSON.parse(toolResult.result as string);
+          if (!parsed?.success || !parsed?.data) {
+            throw apiError;
+          }
+
+          setWaveCute(parsed.data as WaveCuteDetail);
+        } catch (fallbackError) {
+          if (!cancelled) {
+            setError(
+              fallbackError instanceof Error
+                ? fallbackError.message
+                : "Unable to load Wave Cute detail."
+            );
+          }
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchWaveCuteDetail();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [waveCuteId, callTool]);
+
+  const timeRemainingBadge = useMemo(() => {
+    if (!waveCute?.activeWave?.submissionDeadline) {
+      return null;
+    }
+    return getTimeRemaining(waveCute.activeWave.submissionDeadline);
+  }, [waveCute?.activeWave?.submissionDeadline]);
+
+  const communityLinks = useMemo(() => {
+    if (!waveCute?.community) return [];
+
+    return COMMUNITY_CONFIG.filter(({ key }) => waveCute.community?.[key]).map(
+      ({ key, icon, label }) => ({
+        key,
+        icon,
+        label,
+        url: waveCute.community?.[key as keyof CommunityLinks] ?? "",
+      })
+    );
+  }, [waveCute?.community]);
+
+  const criteriaList = useMemo(() => {
+    if (!waveCute?.criteria?.length) return [];
+    return [...waveCute.criteria]
+      .filter((criterion) => criterion.isActive)
+      .sort((a, b) => a.sort - b.sort);
+  }, [waveCute?.criteria]);
+
+  return (
+    <div
+      className="font-sans bg-gradient-to-br from-slate-50 via-cyan-50 to-slate-100 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 p-5"
+      style={{
+        maxHeight: maxHeight ? `${maxHeight}px` : "100vh",
+        height:
+          displayMode === "fullscreen"
+            ? maxHeight
+              ? `${maxHeight}px`
+              : "100vh"
+            : "auto",
+        minHeight: maxHeight ? `${maxHeight}px` : "100vh",
+        overflow: "auto",
+      }}
+    >
+      {displayMode !== "fullscreen" && (
+        <button
+          aria-label="Enter fullscreen"
+          className="fixed top-4 right-4 z-50 rounded-full bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 shadow-lg ring-1 ring-slate-900/10 dark:ring-white/10 p-2.5 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors cursor-pointer"
+          onClick={() => requestDisplayMode("fullscreen")}
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"
+            />
+          </svg>
+        </button>
+      )}
+
+      {!isChatGptApp && (
+        <div className="bg-sky-50 dark:bg-sky-950 border border-sky-200 dark:border-sky-800 rounded-lg px-4 py-3 mb-6 max-w-4xl mx-auto">
+          <div className="flex items-start gap-3">
+            <svg
+              className="w-5 h-5 text-sky-600 dark:text-sky-400 flex-shrink-0"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm-.75-11.75a.75.75 0 011.5 0v3.5a.75.75 0 01-1.5 0v-3.5zM10 13a1 1 0 110 2 1 1 0 010-2z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                Tip
+              </p>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Use the fullscreen button for a richer experience, then click
+                any community links to dive deeper into this Wave Cute.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="max-w-5xl mx-auto space-y-6">
+        <header className="space-y-2 text-center">
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Wave Cute Detail
+          </p>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100">
+            {waveCute?.title ?? "Wave Cute Viewer"}
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            ID: <span className="font-mono text-slate-700 dark:text-slate-200">{waveCuteId || "—"}</span>
+          </p>
+        </header>
+
+        {loading && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="animate-spin rounded-full h-14 w-14 border-b-2 border-sky-600"></div>
+            <p className="mt-6 text-slate-700 dark:text-slate-300">
+              Fetching Wave Cute details…
+            </p>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="max-w-3xl mx-auto bg-rose-50 dark:bg-rose-950/40 border border-rose-200 dark:border-rose-900 rounded-lg p-6">
+            <div className="flex gap-3">
+              <div className="flex-shrink-0 text-rose-600 dark:text-rose-300 text-xl">
+                ❌
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-lg font-semibold text-rose-700 dark:text-rose-200">
+                  Unable to load details
+                </h2>
+                <p className="text-sm text-rose-600 dark:text-rose-300">
+                  {error}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && waveCute && (
+          <section className="bg-white dark:bg-slate-900/70 shadow-xl ring-1 ring-slate-900/5 dark:ring-white/10 rounded-2xl p-6 space-y-8">
+            <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+              <div className="space-y-2">
+                <p className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-medium bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-200">
+                  Active Wave
+                  <span className="inline-flex items-center gap-1 font-normal text-slate-500 dark:text-slate-300">
+                    🕒 {formatDate(waveCute.activeWave?.startedAt)}
+                  </span>
+                </p>
+                <div className="space-y-1">
+                  <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+                    {waveCute.title}
+                  </h2>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Stay on top of deadlines, prize info, and judging criteria.
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-3">
+                {timeRemainingBadge && (
+                  <span
+                    className={`text-xs font-semibold px-3 py-1 rounded-full ${getBadgeStyles(
+                      timeRemainingBadge.variant
+                    )}`}
+                  >
+                    {timeRemainingBadge.label}
+                  </span>
+                )}
+                <a
+                  href={`https://app.akindo.io/wave-hacks/${waveCute.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-sky-600 hover:bg-sky-700 text-white text-sm font-medium transition-colors"
+                >
+                  Visit on Akindo
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M5 12h14M12 5l7 7-7 7"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+
+            <div className="grid gap-5 lg:grid-cols-2">
+              <div className="relative overflow-hidden rounded-xl bg-slate-50 dark:bg-slate-800/80 p-5">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                    Build & Judging Window
+                  </h3>
+                  <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                    Timeline overview
+                  </span>
+                </div>
+                <dl className="space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                  <div className="flex justify-between">
+                    <dt className="font-medium">Building Phase</dt>
+                    <dd>{waveCute.buildingDays ?? "—"} days</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="font-medium">Judging Phase</dt>
+                    <dd>{waveCute.judgingDays ?? "—"} days</dd>
+                  </div>
+                  <div className="pt-3 border-t border-slate-200 dark:border-slate-700 space-y-2">
+                    {TIMELINE_FIELDS.map(({ key, label }) => (
+                      <div
+                        key={key}
+                        className="flex justify-between gap-4 text-xs"
+                      >
+                        <span className="text-slate-500 dark:text-slate-400">
+                          {label}
+                        </span>
+                        <span className="text-right font-medium text-slate-700 dark:text-slate-200">
+                          {formatDate(
+                            waveCute.activeWave?.[
+                              key as keyof ActiveWaveInfo
+                            ]
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </dl>
+              </div>
+
+              <div className="relative overflow-hidden rounded-xl bg-white dark:bg-slate-800/80 border border-slate-100 dark:border-slate-700 p-5">
+                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200 mb-3">
+                  Prize Pool
+                </h3>
+                {waveCute.grantDenomination?.name &&
+                waveCute.activeWave?.grantAmount ? (
+                  <div className="space-y-2">
+                    <p className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+                      {parseFloat(
+                        waveCute.activeWave.grantAmount
+                      ).toLocaleString("en-US")}{" "}
+                      {waveCute.grantDenomination.name}
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Token Address:{" "}
+                      <span className="font-mono text-slate-600 dark:text-slate-300 break-all">
+                        {waveCute.grantDenomination.address}
+                      </span>
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Decimals: {waveCute.grantDenomination.decimals}
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Prize information is not available for this Wave Cute.
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200 mb-3">
+                Description
+              </h3>
+              <div className="bg-slate-50 dark:bg-slate-800/80 rounded-xl border border-slate-100 dark:border-slate-700 p-5 max-h-72 overflow-y-auto text-sm text-slate-700 dark:text-slate-300">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    h1: ({ children }) => (
+                      <h1 className="text-lg font-bold mb-2">{children}</h1>
+                    ),
+                    h2: ({ children }) => (
+                      <h2 className="text-md font-semibold mb-2">
+                        {children}
+                      </h2>
+                    ),
+                    h3: ({ children }) => (
+                      <h3 className="text-sm font-semibold mb-1">
+                        {children}
+                      </h3>
+                    ),
+                    p: ({ children }) => <p className="mb-2">{children}</p>,
+                    a: ({ href, children }) => (
+                      <a
+                        href={href ?? "#"}
+                        className="text-sky-600 hover:text-sky-800 underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {children}
+                      </a>
+                    ),
+                    ul: ({ children }) => (
+                      <ul className="list-disc ml-4 mb-2">{children}</ul>
+                    ),
+                    ol: ({ children }) => (
+                      <ol className="list-decimal ml-4 mb-2">{children}</ol>
+                    ),
+                    li: ({ children }) => <li className="mb-1">{children}</li>,
+                    blockquote: ({ children }) => (
+                      <blockquote className="border-l-4 border-slate-300 pl-4 italic mb-2">
+                        {children}
+                      </blockquote>
+                    ),
+                    code: ({ children }) => (
+                      <code className="bg-slate-200 dark:bg-slate-700 px-1 py-0.5 rounded text-xs">
+                        {children}
+                      </code>
+                    ),
+                    pre: ({ children }) => (
+                      <pre className="bg-slate-200 dark:bg-slate-700 p-2 rounded overflow-x-auto mb-2 text-xs">
+                        {children}
+                      </pre>
+                    ),
+                    img: ({ src, alt }) =>
+                      src ? (
+                        <img
+                          src={src}
+                          alt={alt ?? ""}
+                          className="max-w-full h-auto rounded mb-2"
+                        />
+                      ) : null,
+                    iframe: ({ src, width, height }) =>
+                      src ? (
+                        <iframe
+                          src={src}
+                          width={width ?? "100%"}
+                          height={height ?? "315"}
+                          className="w-full rounded mb-2"
+                          allowFullScreen
+                        />
+                      ) : null,
+                  }}
+                >
+                  {waveCute.description ?? "No description available for this Wave Cute."}
+                </ReactMarkdown>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                Community Links
+              </h3>
+              {communityLinks.length > 0 ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {communityLinks.map(({ key, icon, label, url }) => (
+                    <a
+                      key={key}
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center p-4 rounded-xl bg-slate-50 dark:bg-slate-800/80 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                    >
+                      <span className="flex-shrink-0 w-6 h-6 mr-3 text-lg">
+                        {icon}
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                          {label}
+                        </p>
+                        <p className="text-xs text-slate-500 dark:text-slate-400 truncate">
+                          {url}
+                        </p>
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  No community links have been provided.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                Judging Criteria
+              </h3>
+              {criteriaList.length > 0 ? (
+                <div className="space-y-3">
+                  {criteriaList.map((criterion) => (
+                    <div
+                      key={criterion.id}
+                      className="flex items-center justify-between rounded-xl bg-slate-50 dark:bg-slate-800/80 px-4 py-3"
+                    >
+                      <span className="text-sm text-slate-800 dark:text-slate-100">
+                        {criterion.title}
+                      </span>
+                      <span className="text-xs font-semibold px-3 py-1 rounded-full bg-cyan-100 text-cyan-800 dark:bg-cyan-900/50 dark:text-cyan-200">
+                        #{criterion.sort}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Judging criteria will be announced soon.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(mcp-ui)/view-wave-cute/page.tsx
+++ b/src/app/(mcp-ui)/view-wave-cute/page.tsx
@@ -7,6 +7,7 @@ import {
   useDisplayMode,
   useRequestDisplayMode,
   useIsChatGptApp,
+  useSendMessage,
 } from "@/app/hooks";
 import { useCallTool } from "@/app/hooks/use-call-tool";
 
@@ -53,6 +54,7 @@ export default function ViewWaveHacksPage() {
   const requestDisplayMode = useRequestDisplayMode();
   const isChatGptApp = useIsChatGptApp();
   const callTool = useCallTool();
+  const sendMessage = useSendMessage();
 
   const [waveHacksData, setWaveHacksData] = useState<WaveHacksData | null>(null);
   const [statusMessage, setStatusMessage] = useState("");
@@ -390,7 +392,7 @@ export default function ViewWaveHacksPage() {
                       </div>
 
                       {/* Status */}
-                      <div className="flex items-center justify-between">
+                      <div className="flex items-center justify-between gap-3">
                         <span className={`inline-flex px-3 py-1 text-sm font-semibold rounded-full ${
                           hack.isPublic 
                             ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' 
@@ -398,6 +400,15 @@ export default function ViewWaveHacksPage() {
                         }`}>
                           {hack.isPublic ? 'Public' : 'Private'}
                         </span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            sendMessage(`view_wave_cute_detail ID: ${hack.id}`)
+                          }
+                          className="inline-flex items-center px-3 py-1 text-xs font-semibold rounded-md bg-cyan-600 hover:bg-cyan-700 text-white transition-colors"
+                        >
+                          View Details
+                        </button>
                       </div>
                     </div>
                   );

--- a/src/app/api/wave-hack/[id]/route.ts
+++ b/src/app/api/wave-hack/[id]/route.ts
@@ -24,7 +24,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = params;
+    const { id } = await params;
     
     if (!id) {
       return NextResponse.json({

--- a/src/tools/fetch-wave-hack.ts
+++ b/src/tools/fetch-wave-hack.ts
@@ -4,13 +4,17 @@ import ky from "ky";
 
 // Define the schema for tool parameters
 export const schema = {
-  id: z.string().describe("The Wave Cute ID to fetch details for"),
+  id: z
+    .string()
+    .min(1, "Wave Cute ID is required")
+    .describe("The Wave Cute ID to fetch details for"),
 };
 
 // Define tool metadata
 export const metadata: ToolMetadata = {
   name: "fetch_wave_cute",
-  description: "Fetch detailed information about a specific Wave Cute by ID from Akindo API",
+  description:
+    "Fetch detailed information about a specific Wave Cute by ID from the Akindo API",
   annotations: {
     title: "Fetch Wave Cute Details",
     readOnlyHint: true,
@@ -41,27 +45,27 @@ interface WaveCuteDetailResponse {
 export default async function fetchWaveCute({
   id,
 }: InferSchema<typeof schema>) {
-  try {
-    if (!id) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              {
-                success: false,
-                error: "Wave cute id is required",
-              },
-              null,
-              2
-            ),
-          },
-        ],
-        isError: true,
-      };
-    }
+  if (!id) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: false,
+              error: "Wave Cute ID is required",
+              timestamp: new Date().toISOString(),
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
 
-    // Create ky instance with retry logic
+  try {
     const api = ky.create({
       timeout: 30000,
       retry: {
@@ -71,9 +75,7 @@ export default async function fetchWaveCute({
       },
     });
 
-    // Fetch wave cute details from Akindo API
     const waveCuteUrl = `https://api.akindo.io/public/wave-hacks/${id}`;
-
     console.log(`Fetching wave cute details for ID: ${id}`);
     console.log(`URL: ${waveCuteUrl}`);
 
@@ -102,23 +104,19 @@ export default async function fetchWaveCute({
       ],
     };
   } catch (error) {
-    // Handle different types of errors
     let errorMessage = "Unknown error occurred";
 
     if (error instanceof Error) {
       errorMessage = error.message;
 
-      // Check if it's a network/HTTP error
       if (error.message.includes("404")) {
-        errorMessage = "Wave cute not found";
+        errorMessage = "Wave Cute not found";
       } else if (error.message.includes("timeout")) {
         errorMessage = "Request timeout - the API is taking too long to respond";
       } else if (error.message.includes("network")) {
         errorMessage = "Network error - unable to reach the API";
       }
     }
-
-    console.error("Error fetching wave cute details:", error);
 
     return {
       content: [
@@ -130,8 +128,6 @@ export default async function fetchWaveCute({
               error: errorMessage,
               timestamp: new Date().toISOString(),
               debug: {
-                originalError:
-                  error instanceof Error ? error.message : "Unknown error",
                 waveCuteId: id,
               },
             },
@@ -144,4 +140,3 @@ export default async function fetchWaveCute({
     };
   }
 }
-

--- a/src/tools/view-wave-cute-detail.ts
+++ b/src/tools/view-wave-cute-detail.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+import { getAppsSdkCompatibleHtml, baseURL } from "@/lib/apps-sdk-html";
+
+// Define the schema for tool parameters
+export const schema = {
+  id: z
+    .string()
+    .min(1, "Wave Cute ID is required")
+    .describe("The Wave Cute ID to display details for"),
+};
+
+// Define tool metadata
+export const metadata: ToolMetadata = {
+  name: "view_wave_cute_detail",
+  description:
+    "Display detailed information about a specific Wave Cute by ID from the Akindo API",
+  annotations: {
+    title: "View Wave Cute Detail",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+  _meta: {
+    openai: {
+      toolInvocation: {
+        invoking: "Loading wave cute details",
+        invoked: "Wave cute detail ready",
+      },
+      widgetAccessible: true,
+      resultCanProduceWidget: true,
+    },
+  },
+};
+
+// Tool implementation
+export default async function viewWaveCuteDetail({
+  id,
+}: InferSchema<typeof schema>) {
+
+
+  try {
+    const html = await getAppsSdkCompatibleHtml(
+      baseURL,
+      "/view-wave-cute-detail"
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `<html>${html}</html>`,
+        },
+      ],
+      structuredContent: { id },
+    };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error occurred";
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: false,
+              error: errorMessage,
+              timestamp: new Date().toISOString(),
+              debug: {
+                waveCuteId: id,
+              },
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+


### PR DESCRIPTION
Add a new tool src/tools/view-wave-cute-detail.ts to render detailed Wave Cute HTML via the apps SDK.
- Defineod schema and ToolMetadata
- Implement handler to fetch compatible HTML and return structured content
- Provide error handling that returns JSON error/debug info

fix(app/api): 🔧 correct param handling in wave-hack route

Await params when destructuring id to avoid runtime errors

build(xmcp/adapter): 📦 include view-wave-cute-detail in import map

Expose the new tool in the adapter import map so it can be loaded at runtime