### PR TITLE
📦(deploy): ⚡ switch install/build to bun for vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "buildCommand": "pnpm run build",
+  "buildCommand": "bun run build",
   "outputDirectory": ".next",
-  "installCommand": "pnpm install --frozen-lockfile"
+  "installCommand": "bun install --frozen-lockfile"
 }


### PR DESCRIPTION
Use bun for install and build commands in vercel.json to replace pnpm.
This updates installCommand to "bun install --frozen-lockfile" and buildCommand to "bun run build".

Reason: move deployment environment to bun runtime for faster installs and consistency with project setup.