### PR TITLE
ci(workflows): ⚙️ cloudflare deploy workflow and disable vercel

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,97 @@
+name: "☁️ Deploy to Cloudflare Workers"
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  deploy-worker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: "📥 Checkout code"
+        uses: actions/checkout@v4
+
+      - name: "🧰 Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: "🛠️ Setup Bun"
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: "📦 Install dependencies"
+        run: |
+          bun install --frozen-lockfile
+
+      - name: "🏗️ Build project"
+        run: bun run build
+        env:
+          NODE_ENV: production
+
+      - name: "🛠️ Install Wrangler CLI"
+        run: bun add --global wrangler@latest
+
+      - name: "☁️ Deploy Worker"
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_ENVIRONMENT: ${{ vars.CLOUDFLARE_ENVIRONMENT }}
+        run: |
+          if [ ! -f wrangler.toml ]; then
+            echo "::error::wrangler.toml not found at repository root. Add the file before running this workflow."
+            exit 1
+          fi
+
+          if [ -n "$WRANGLER_ENVIRONMENT" ]; then
+            DEPLOYMENT_OUTPUT=$(wrangler deploy --env "$WRANGLER_ENVIRONMENT" 2>&1)
+          else
+            DEPLOYMENT_OUTPUT=$(wrangler deploy 2>&1)
+          fi
+
+          DEPLOYMENT_URL=$(echo "$DEPLOYMENT_OUTPUT" | grep -o "https://[^ ]*\.workers\.dev" | head -1)
+
+          if [ -n "$DEPLOYMENT_URL" ]; then
+            echo "✅ Deployment URL: $DEPLOYMENT_URL"
+            echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "⚠️ Could not extract deployment URL from Wrangler output"
+            echo "Full output:"
+            echo "$DEPLOYMENT_OUTPUT"
+          fi
+
+      - name: "🏷️ Update repository homepage URL"
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const deploymentUrl = '${{ steps.deploy.outputs.deployment_url }}';
+
+            if (!deploymentUrl) {
+              console.log('No deployment URL found, skipping homepage update');
+              return;
+            }
+
+            console.log(`Updating repository homepage to: ${deploymentUrl}`);
+
+            try {
+              await github.rest.repos.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                homepage: deploymentUrl
+              });
+              console.log('Successfully updated repository homepage URL');
+            } catch (error) {
+              console.error('Failed to update repository homepage URL:', error);
+              // Don't fail the workflow if homepage update fails
+            }

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build-and-deploy:
+    if: false
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
     "swc-loader": "^0.2.6",
     "tailwindcss": "^4.1.14",
     "typescript": "^5.9.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Added a new GitHub Actions workflow to deploy to Cloudflare Workers, including steps to checkout, setup Node/Bun, install deps, build, install wrangler, deploy, and update repository homepage. Also disabled the existing Vercel deploy job by gating it with `if: false`. Added packageManager field to package.json.

- add .github/workflows/deploy-cloudflare.yml with deployment, env handling, and homepage update
- update .github/workflows/deploy-vercel.yml to skip existing job
- add packageManager entry to package.json

This change updates CI/CD configuration to prefer Cloudflare Workers deployment while keeping Vercel job inert.