### PR TITLE
ci(workflows):⚙️ redundant type-check step from deploy workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Type check
-        run: bun run type-check
-
       - name: Build for Cloudflare Workers
         run: bun run workers:build
         env:


### PR DESCRIPTION
Remove the separate "Type check" step from the Cloudflare deploy GitHub Actions workflow. Type checking is no longer required here (or is handled elsewhere), so the workflow is simplified and the job runs slightly faster.