### PR TITLE
✨ feat(config): add cloudflare config for opennext

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,0 +1,6 @@
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+
+export default defineCloudflareConfig({
+  // Caching configuration can be added here if needed
+  // See: https://opennext.js.org/cloudflare/caching
+});


### PR DESCRIPTION
Add a basic open-next.config.ts exporting aflare config via
defineCloudflareConfig. This provides a place to add caching or other
Cloudflare-specific settings for the OpenNext deployment.

No functional behavior changed — configuration scaffold only.