### PR TITLE
⚙️ ci(workflows): set VERCEL_URL as Cloudflare worker secret and simplify deploy steps

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -145,28 +145,15 @@ jobs:
           echo "worker_domain=https://${WORKER_NAME}.uratmangun.workers.dev" >> $GITHUB_OUTPUT
           echo "preview_domain=https://${WORKER_NAME}-preview.uratmangun.workers.dev" >> $GITHUB_OUTPUT
 
-      - name: Sync VERCEL_URL for production worker
+      - name: Set VERCEL_URL secret for production worker
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
         env:
           TARGET_VERCEL_URL: ${{ steps.generate-worker-name.outputs.worker_domain }}
         run: |
-          python3 - <<'PY'
-          import os, pathlib, re
-          path = pathlib.Path("wrangler.toml")
-          text = path.read_text()
-          domain = os.environ["TARGET_VERCEL_URL"]
-
-          if "VERCEL_URL" in text:
-              text = re.sub(r'VERCEL_URL\s*=\s*".*?"', f'VERCEL_URL = "{domain}"', text)
-          elif 'ENVIRONMENT = "production"' in text:
-              text = text.replace('ENVIRONMENT = "production"', 'ENVIRONMENT = "production"\nVERCEL_URL = "' + domain + '"', 1)
-          elif "[vars]" in text:
-              text = text.replace("[vars]\n", "[vars]\nVERCEL_URL = \"" + domain + "\"\n", 1)
-          else:
-              text += "\n[vars]\nVERCEL_URL = \"" + domain + "\"\n"
-
-          path.write_text(text)
-          PY
+          curl -X PUT "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/workers/scripts/${{ steps.generate-worker-name.outputs.worker_name }}/secrets" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\": \"VERCEL_URL\", \"text\": \"${TARGET_VERCEL_URL}\", \"type\": \"secret_text\"}"
 
       - name: Deploy to Cloudflare Workers (Production)
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
@@ -179,40 +166,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Sync VERCEL_URL for preview worker
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          TARGET_VERCEL_URL: ${{ steps.generate-worker-name.outputs.preview_domain }}
-        run: |
-          python3 - <<'PY'
-          import os, pathlib, re
-          path = pathlib.Path("wrangler.toml")
-          text = path.read_text()
-          domain = os.environ["TARGET_VERCEL_URL"]
-
-          if "VERCEL_URL" in text:
-              text = re.sub(r'VERCEL_URL\s*=\s*".*?"', f'VERCEL_URL = "{domain}"', text)
-          elif 'ENVIRONMENT = "production"' in text:
-              text = text.replace('ENVIRONMENT = "production"', 'ENVIRONMENT = "production"\nVERCEL_URL = "' + domain + '"', 1)
-          elif "[vars]" in text:
-              text = text.replace("[vars]\n", "[vars]\nVERCEL_URL = \"" + domain + "\"\n", 1)
-          else:
-              text += "\n[vars]\nVERCEL_URL = \"" + domain + "\"\n"
-
-          path.write_text(text)
-          PY
-
-      - name: Deploy to Cloudflare Workers (Preview)
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          # Update wrangler.toml with the generated worker name and preview suffix
-          sed -i "s/^name = .*/name = \"${{ steps.generate-worker-name.outputs.worker_name }}-preview\"/" wrangler.toml
-          # Deploy using opennextjs-cloudflare
-          bun run deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
+       
       - name: Update repository homepage URL
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
         uses: actions/github-script@v7
@@ -236,16 +190,4 @@ jobs:
               // Don't fail the workflow if homepage update fails
             }
 
-      - name: Comment deployment URL
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const deployment = `https://${{ steps.generate-worker-name.outputs.worker_name }}-preview.workers.dev`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `✅ Preview deployment ready!\n\n🔗 ${deployment}`
-            });
+  


### PR DESCRIPTION
Switch sync logic from editing wrangler.toml via python to using Cloudflare API to store VERCEL_URL as a secret for the production worker. Remove duplicate preview VERCEL_URL sync and preview-specific deploy steps; unify deploy invocation. Keep Cloudflare credentials in workflow env and update homepage step placement. 

This reduces file mutation, centralizes secret management, and simplifies the CI workflow.