### PR TITLE
ci(deploy): ⚙️ fix indentation in cloudflare deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -164,7 +164,7 @@ jobs:
             addEventListener('fetch', event => {
               event.respondWith(new Response('Deployment placeholder', { status: 200 }));
             });
-              EOF
+            EOF
             CREATE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "$API_URL" \
               -H "$AUTH_HEADER" \
               -H "Content-Type: application/javascript" \


### PR DESCRIPTION
Adjust indentation of heredoc terminator in .github/workflows/deploy-cloudflare.yml so the EOF aligns with script block This corrects the YAML/script formatting for creating the worker code during deployment.